### PR TITLE
fixed key collisions in signal function lookup

### DIFF
--- a/qml.go
+++ b/qml.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"github.com/nanu-c/qml-go/gl/glbase"
 	"image"
 	"image/color"
 	"io"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"unsafe"
+
+	"github.com/nanu-c/qml-go/gl/glbase"
 )
 
 // Engine provides an environment for instantiating QML components.
@@ -801,6 +802,12 @@ func (obj *Common) On(signal string, function interface{}) {
 	var cerr *C.error
 	RunMain(func() {
 		funcr := C.GoRef(uintptr(unsafe.Pointer(&function)))
+		for {
+			if _, ok := connectedFunction[funcr]; !ok {
+				break
+			}
+			funcr++
+		}
 		cerr = C.objectConnect(obj.addr, csignal, csignallen, obj.engine.addr, funcr, C.int(funcv.Type().NumIn()))
 		if cerr == nil {
 			connectedFunction[funcr] = function
@@ -1097,9 +1104,9 @@ func LoadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.registerResourceData(C.int(r.version), tree, name, data)
 }
 
@@ -1111,8 +1118,8 @@ func UnloadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.unregisterResourceData(C.int(r.version), tree, name, data)
 }


### PR DESCRIPTION
Hi,

this fixes sporadic ocurring key collisions in `connectedFunction` in qml.go.

Result often was a `unknown data type` panic with a huge value because of different function signatures and uninitialised `DataValue args[MaxParams]` in Connector.cpp.