### PR TITLE
Fixes for Go 1.15 and Qt 5.15.1

### DIFF
--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -65,8 +65,10 @@ typedef enum {
 
 typedef struct {
     DataType dataType;
+    char _pad0[4];
     char data[8];
     int len;
+    char _pad1[4];
 } DataValue;
 
 typedef struct {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nanu-c/qml-go
+
+go 1.15

--- a/qml.go
+++ b/qml.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"github.com/neclepsio/qml/gl/glbase"
 	"image"
 	"image/color"
 	"io"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"unsafe"
+
+	"github.com/nanu-c/qml-go/gl/glbase"
 )
 
 // Engine provides an environment for instantiating QML components.
@@ -801,6 +802,12 @@ func (obj *Common) On(signal string, function interface{}) {
 	var cerr *C.error
 	RunMain(func() {
 		funcr := C.GoRef(uintptr(unsafe.Pointer(&function)))
+		for {
+			if _, ok := connectedFunction[funcr]; !ok {
+				break
+			}
+			funcr++
+		}
 		cerr = C.objectConnect(obj.addr, csignal, csignallen, obj.engine.addr, funcr, C.int(funcv.Type().NumIn()))
 		if cerr == nil {
 			connectedFunction[funcr] = function
@@ -1097,9 +1104,9 @@ func LoadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.registerResourceData(C.int(r.version), tree, name, data)
 }
 
@@ -1111,8 +1118,8 @@ func UnloadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.unregisterResourceData(C.int(r.version), tree, name, data)
 }


### PR DESCRIPTION
Hi,

Go 1.14 introduced `checkptr`, an alignment check for pointers to Go values. This check occures at runtime at casts from/to `unsafe.Pointer` if the binary was compiled with `-race` or `-msan`. I added paddings in `C.DataType` to prevent `checkptr` panics.

Qt 5.15 has changes in a public API that qml-go was using. `QQmlListProperty::dummy1 dummy2` are gone. With this fix now all values are stored in `QQmlListProperty::data` (requires memory allocation).

I had to backport these fixes to an earlier branch (`neclepsio:master`). The current master somewhere introduced a change that causes sporadic deadlocks (GUI freezes). The merge applies the fixes from the backport to master.